### PR TITLE
Fix test

### DIFF
--- a/internal/rethinkdb/codec_test.go
+++ b/internal/rethinkdb/codec_test.go
@@ -1,9 +1,10 @@
 package rethinkdb
 
 import (
+	"testing"
+
 	frontierV1 "github.com/nlnwa/veidemann-api/go/frontier/v1"
 	"google.golang.org/protobuf/encoding/protojson"
-	"testing"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -35,7 +36,7 @@ func TestUnmarshal(t *testing.T) {
 
 	var jes frontierV1.JobExecutionStatus
 	if err := (protojson.UnmarshalOptions{AllowPartial: true}).Unmarshal([]byte(jesJSON), &jes); err != nil {
-		t.Errorf("failed to unmarshal json to job execution status: %w", err)
+		t.Errorf("failed to unmarshal json to job execution status: %v", err)
 	}
 
 }


### PR DESCRIPTION
This PR fixes the following error that fails tests:

```
internal/rethinkdb/codec_test.go:38:3: (*testing.common).Errorf does not support error-wrapping directive %w
```